### PR TITLE
Update for new Github URL location

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -29,7 +29,7 @@ get_download_url() {
   local version="$1"
   local platform
   platform="$(get_arch)"
-  echo "https://github.com/tfsec/tfsec/releases/download/v${version}/tfsec-${platform}"
+  echo "https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-${platform}"
 }
 
 install_tfsec "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-release_path=https://api.github.com/repos/tfsec/tfsec/releases
+release_path=https://api.github.com/repos/aquasecurity/tfsec/releases
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"


### PR DESCRIPTION
Update to URLs due to announcement of TFSec takeover.
https://github.com/aquasecurity/tfsec