### PR TITLE
fix(list-all): increase pagination limit to maximum

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-release_path=https://api.github.com/repos/aquasecurity/tfsec/releases
+release_path="https://api.github.com/repos/aquasecurity/tfsec/releases?per_page=100"
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
-cmd="$cmd $release_path"
+cmd="$cmd -H 'Accept: application/vnd.github.v3+json' $release_path"
 
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \


### PR DESCRIPTION
Use GitHub API pagination to get more releases by default

Fixes #6 