### PR TITLE
feat(cpu): support ARM architecture binary downloads

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,14 +22,29 @@ install_tfsec() {
 }
 
 get_arch() {
-    echo "$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+    echo "$(uname | tr '[:upper:]' '[:lower:]')"
+}
+
+get_cpu() {
+  local machine_hardware_name
+  machine_hardware_name=${ASDF_TFSEC_OVERWRITE_ARCH:-"$(uname -m)"}
+
+  case "$machine_hardware_name" in
+    'x86_64') local cpu_type="amd64" ;;
+    'aarch64') local cpu_type="arm64" ;;
+    *) local cpu_type="$machine_hardware_name" ;;
+  esac
+
+  echo "$cpu_type"
 }
 
 get_download_url() {
   local version="$1"
   local platform
   platform="$(get_arch)"
-  echo "https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-${platform}"
+  local cpu
+  cpu=$(get_cpu)
+  echo "https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-${platform}-${cpu}"
 }
 
 install_tfsec "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
`tfsec` is available for ARM via https://github.com/aquasecurity/tfsec/releases/ but currently this ASDF plugin downloads the amd64 variant which leads to errors like:

`/home/runner/.asdf/lib/commands/command-exec.bash: line 28: /home/runner/.asdf/installs/tfsec/1.28.1/bin/tfsec: cannot execute binary file: Exec format error`

I have access to amd64 and arm64 machines and tested the proposed snippet on both. You can also simulate being on an arm64 machine by setting `ASDF_TFSEC_OVERWRITE_ARCH=aarch64`.

Inspired by https://github.com/asdf-community/asdf-kubectl/blob/cbe6df49865a52ad5e6e430dff33f474785ff2bf/bin/install#L30-L56